### PR TITLE
Implement Tailwind styled todo form

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, render_template, redirect, url_for
 import openai
 import requests
 import hashlib
@@ -7,6 +7,9 @@ import base64
 import os
 
 app = Flask(__name__)
+
+# Simple in-memory todo list
+tasks = []
 
 # ✅ OpenAI APIキー（環境変数から取得）
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -82,3 +85,19 @@ def callback():
 def home():
     """ 確認用のルート """
     return "LINE Bot is running!", 200
+
+
+@app.route("/todo", methods=["GET"])
+def todo_page():
+    """Todo list page"""
+    return render_template("todo.html", tasks=tasks, error=None)
+
+
+@app.route("/add_todo", methods=["POST"])
+def add_todo():
+    """Handle adding a new todo item"""
+    task = request.form.get("task", "").strip()
+    if not task:
+        return render_template("todo.html", tasks=tasks, error="Task cannot be empty"), 400
+    tasks.append(task)
+    return redirect(url_for("todo_page"))

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Todo App</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 py-10">
+  <div class="max-w-md mx-auto bg-white p-6 rounded shadow">
+    <h1 class="text-xl font-bold mb-4">Todo List</h1>
+    <form id="todo-form" class="flex mb-4" method="post" action="/add_todo">
+      <input id="task-input" name="task" type="text" placeholder="Add new task" class="flex-1 px-3 py-2 border rounded-l" />
+      <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded-r">Add</button>
+    </form>
+    {% if error %}
+      <p class="text-red-500 mb-2">{{ error }}</p>
+    {% endif %}
+    <ul>
+      {% for item in tasks %}
+        <li class="border-b py-2">{{ item }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+  <script>
+    document.getElementById('todo-form').addEventListener('submit', function(e) {
+      const input = document.getElementById('task-input');
+      if (!input.value.trim()) {
+        e.preventDefault();
+        alert('Task cannot be empty');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/test_todo.py
+++ b/test_todo.py
@@ -1,0 +1,27 @@
+import pytest
+from app import app, tasks
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_get_todo_page(client):
+    res = client.get('/todo')
+    assert res.status_code == 200
+    assert b'Todo List' in res.data
+
+
+def test_post_empty_task(client):
+    res = client.post('/add_todo', data={'task': ''})
+    assert res.status_code == 400
+    assert b'Task cannot be empty' in res.data
+
+
+def test_post_valid_task(client):
+    tasks.clear()
+    res = client.post('/add_todo', data={'task': 'Test Task'})
+    assert res.status_code == 302
+    assert tasks[-1] == 'Test Task'


### PR DESCRIPTION
## Summary
- add a Tailwind based todo page
- validate that todo text is not empty
- expose `/todo` and `/add_todo` endpoints
- provide tests for the todo feature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686208b68acc832db6184952e234e2ee